### PR TITLE
fix sge profile

### DIFF
--- a/conf/sge.config
+++ b/conf/sge.config
@@ -1,10 +1,13 @@
 process {
-  process.executor = "sge"
-  process.queue = "all.q"
-  process.penv = 'smp 4,8'
-  executor.queueSize = 100
-  executor.cpus = 8
-  executor.memory = '16 GB'
+  executor = "sge"
+  queue = "all.q"
+  penv = 'smp'
+}
+
+executor {
+  queueSize = 100
+  cpus = 8
+  memory = '16 GB'
 }
 
 params	{

--- a/main.nf
+++ b/main.nf
@@ -1062,6 +1062,9 @@ process check_local_blast_database {
   when: 
   params.blast_unassigned_sequences
 
+  input:
+  path(params.local_nt_database)
+
   output:
   val("db_check_complete") into post_blast_db_check_ch
 
@@ -1166,6 +1169,7 @@ process blast_unassigned_sequences {
   input:
   path(unassigned_sequences) from post_assign_to_refseq_ch
   path(blast_tax_dir) from post_blast_tax_check_ch
+  path(params.local_nt_database)
 
   output:
   path("${unassigned_sequences}.bn_nt") into post_blast_unassigned_ch


### PR DESCRIPTION
Made changes to `conf/sge_profile.conf` and `main.nf`.

Changes to `sge_profile.conf` are to fix queueSize not being recognized as a valid option because it's within the `process` block.

Changes to `main.nf` are to make it so the `blast_db` path is properly passed to the work enviornment of nextflow steps using it (including it under `input` as a path() causes it to be symlinked properly).